### PR TITLE
v1.3.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,33 @@ An example can be found in the “Example” project.
 ## 1.2.1
 ### Changed
 - `size_tailored_text` 의존성을 1.1.0으로 상향했습니다.
+
+## 1.3.0
+### Added
+- 키별 `onPressed` 콜백을 `VirtualKey`에 추가했습니다. 키가 눌리면 전역 리스너와
+  별개로, 입력이 반영된 뒤 호출됩니다.
+- `SoftKeyboardWidget`에 `defaultKeyDecoration` / `defaultKeyTextStyle`를 추가했습니다.
+  모든 키에 공통 적용되며, 개별 `VirtualKey`가 값을 지정하면 그 값이 우선합니다.
+  이제 키마다 decoration/textStyle을 반복하지 않아도 됩니다.
+- 특수키를 간결하게 만드는 팩토리 생성자를 추가했습니다:
+  `VirtualKey.char`, `VirtualKey.backspace`, `VirtualKey.space`,
+  `VirtualKey.enter`, `VirtualKey.clear`.
+- `KeyType`에 `shift`, `capsLock`을 추가했습니다. `shift`는 다음 문자 하나에만
+  적용되는 일회성 토글, `capsLock`은 다시 누를 때까지 유지되는 토글입니다.
+  `VirtualKey.shift()` / `VirtualKey.capsLock()` 팩토리 생성자와,
+  `KeyboardInputController`의 상태 게터(`isShiftEnabled`, `isCapsLockEnabled`,
+  `isUpperCase`)를 함께 제공합니다. Shift/CapsLock 상태에 따라 키 라벨과 입력
+  문자가 대문자로 자동 변환됩니다.
+- `VirtualKey.copyWith`를 추가했습니다.
+
+### Fixed
+- `setKeyListener`를 여러 번 호출하면 이전 리스너가 제거되지 않고 계속 누적되던 문제를 수정했습니다.
+  이제 새 리스너를 등록하기 전에 기존 리스너를 해제합니다.
+- Backspace가 UTF-16 코드 유닛 1개만 제거해 이모지·결합 문자가 깨지던 문제를 수정했습니다.
+  이제 사용자가 인지하는 문자(grapheme cluster) 단위로 제거합니다.
+- `keyLayout`가 비어 있을 때 키 높이 계산에서 0으로 나눠 레이아웃이 깨지던 문제를 방지하는 가드를 추가했습니다.
+
+### Removed
+- 사용되지 않던 `findLongestRowIndex` 메서드를 제거했습니다.
+
+기존 `VirtualKey(...)` 2D 배열 방식과 100% 호환됩니다.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_soft_keyboard: ^1.2.1
+  flutter_soft_keyboard: ^1.3.0
 ```
 
 Then run `flutter pub get`.
@@ -18,17 +18,9 @@ Then run `flutter pub get`.
 
 ## How to Use
 
-~~~
-
+~~~dart
 class _TestState extends State<Test> {
   final keyboardController = KeyboardInputController();
-
-  /// [
-  ///   [VirtualKey(...), VirtualKey(...), ...],
-  ///   [VirtualKey(...), VirtualKey(...), ...],
-  ///   ...
-  /// ]
-  final List<List<VirtualKey>> keyLayout;
 
   @override
   void initState() {
@@ -47,21 +39,71 @@ class _TestState extends State<Test> {
   ...
 
   @override
-  widget build(BuildContext context) {
+  Widget build(BuildContext context) {
     ...
     SoftKeyboardWidget(
-          width: 400,
-          height: 300,
-          columnSpacing: 4,
-          rowSpacing: 4,
-          keyLayout: keyLayout,
-          keyboardInputController: keyboardController,
-        ),
+      width: 400,
+      height: 300,
+      columnSpacing: 4,
+      rowSpacing: 4,
+      // Applied to every key; a per-key value overrides it, so you don't
+      // repeat decoration/textStyle on each key.
+      defaultKeyDecoration: keyDecoration,
+      defaultKeyTextStyle: keyTextStyle,
+      keyLayout: [
+        [
+          VirtualKey.char('1'),
+          VirtualKey.char('2'),
+          VirtualKey.char('3'),
+          VirtualKey.backspace(icon: const Icon(Icons.backspace)),
+        ],
+        [
+          VirtualKey.char('a'),
+          VirtualKey.char('b'),
+          // Per-key callback, in addition to the global key listener.
+          VirtualKey.char('c', onPressed: (key) => print(key.label)),
+        ],
+        [
+          VirtualKey.space(label: 'space'),
+        ],
+      ],
+      keyboardInputController: keyboardController,
+    ),
     ...
   }
 }
-
 ~~~
+
+### Key factory constructors
+
+Instead of `VirtualKey(type: KeyType.backspace, ...)`, use the concise factories:
+
+| Factory | Purpose |
+| --- | --- |
+| `VirtualKey.char('a')` | Inputs the given character |
+| `VirtualKey.backspace()` | Deletes the last (grapheme) character |
+| `VirtualKey.space()` | Inputs a space |
+| `VirtualKey.enter()` | Inputs a newline |
+| `VirtualKey.clear()` | Clears the whole text |
+| `VirtualKey.shift()` | One-shot uppercase for the next character |
+| `VirtualKey.capsLock()` | Persistent uppercase until pressed again |
+
+Every key also accepts an `onPressed` callback that fires (after the input is
+applied) in addition to the global listener set via `setKeyListener`.
+
+### Shift / Caps Lock
+
+Adding a `VirtualKey.shift()` or `VirtualKey.capsLock()` key enables uppercase
+input. `shift` applies to the next single character and then reverts, while
+`capsLock` stays on until pressed again (shift inverts caps lock, like a
+physical keyboard). Both the entered text and the key faces update
+automatically. You can also read the current state from the controller:
+
+```dart
+keyboardController.isShiftEnabled;   // one-shot shift armed?
+keyboardController.isCapsLockEnabled; // caps lock on?
+keyboardController.isUpperCase;       // next character uppercase?
+```
 
 ## Example
 
@@ -74,37 +116,15 @@ class _TestState extends State<Test> {
             <pre><code>
 [
             [
-              VirtualKey(
-                  label: '1',
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle),
-              VirtualKey(
-                  label: '2',
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle),
-              VirtualKey(
-                  label: '3',
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle),
-              VirtualKey(
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle,
-                  type: KeyType.backspace,
-                  icon: Icon(Icons.abc))
+              VirtualKey.char('1'),
+              VirtualKey.char('2'),
+              VirtualKey.char('3'),
+              VirtualKey.backspace(icon: Icon(Icons.backspace)),
             ],
             [
-              VirtualKey(
-                  label: '1',
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle),
-              VirtualKey(
-                  label: '2',
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle),
-              VirtualKey(
-                  label: '3',
-                  decoration: keyDecoration,
-                  textStyle: keyTextStyle)
+              VirtualKey.char('a'),
+              VirtualKey.char('b'),
+              VirtualKey.char('c'),
             ],
           ]</code></pre>
         </td>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 This Flutter package is a virtual keyboard widget that can be implemented using a 2D array.
 
+## What's New in 1.3.0
+
+**Added**
+- **Per-key `onPressed` callback** on `VirtualKey` — fires after the input is applied, alongside the global listener.
+- **`KeyType.shift` / `KeyType.capsLock`** — `shift` is a one-shot uppercase toggle, `capsLock` is persistent. Both the entered text and the key faces update automatically. Read the state via `isShiftEnabled` / `isCapsLockEnabled` / `isUpperCase`.
+- **`defaultKeyDecoration` / `defaultKeyTextStyle`** on `SoftKeyboardWidget` — shared styles are no longer repeated on every key.
+- **Concise key factories** — `VirtualKey.char / backspace / space / enter / clear / shift / capsLock`.
+- **`VirtualKey.copyWith`**.
+
+**Fixed**
+- `setKeyListener` no longer accumulates listeners when called repeatedly.
+- Backspace removes a whole grapheme cluster, so emoji / combined characters are no longer corrupted.
+- Guard against division by zero when `keyLayout` is empty.
+
+> Fully backward compatible with the existing `VirtualKey(...)` 2D-array style. See [CHANGELOG.md](CHANGELOG.md) for full history.
+
 ## Installation
 
 Add to your `pubspec.yaml`:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,8 +48,8 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState() {
     super.initState();
     keyboardController.setKeyListener((lastKey, enteredText) {
-      print('last key type : ${lastKey?.type}');
-      print(enteredText);
+      debugPrint('last key type : ${lastKey?.type}');
+      debugPrint(enteredText);
       setState(() {
         text = enteredText;
       });
@@ -70,56 +70,43 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text(text),
-            SoftKeyboardWidget(
-              width: 400,
-              height: 300,
-              columnSpacing: 6,
-              rowSpacing: 6,
-              keyLayout: [
-                [
-                  VirtualKey(
-                      label: '1',
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle),
-                  VirtualKey(
-                      label: '2',
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle),
-                  VirtualKey(
-                      label: '3',
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle),
-                  VirtualKey(
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle,
-                      type: KeyType.backspace,
-                      iconAlignment: Alignment.center,
-                      icon: const Icon(Icons.backspace))
+            LayoutBuilder(
+              builder: (context, constraints) => SoftKeyboardWidget(
+                width: constraints.maxWidth,
+                height: 300,
+                columnSpacing: 6,
+                rowSpacing: 6,
+                // Applied to every key that doesn't override them, so you no
+                // longer repeat decoration/textStyle on each key.
+                defaultKeyDecoration: keyDecoration,
+                defaultKeyTextStyle: keyTextStyle,
+                keyLayout: [
+                  [
+                    VirtualKey.char('1'),
+                    VirtualKey.char('2'),
+                    VirtualKey.char('3'),
+                    VirtualKey.backspace(icon: const Icon(Icons.backspace)),
+                  ],
+                  [
+                    VirtualKey.char('a'),
+                    VirtualKey.char('b'),
+                    // Per-key onPressed callback example.
+                    VirtualKey.char('c', onPressed: (key) {
+                      debugPrint('pressed: ${key.label}');
+                    }),
+                  ],
+                  [
+                    // shift: one-shot uppercase / capsLock: persistent uppercase.
+                    VirtualKey.shift(icon: const Icon(Icons.arrow_upward)),
+                    VirtualKey.capsLock(icon: const Icon(Icons.keyboard_capslock)),
+                  ],
+                  [
+                    VirtualKey.space(label: 'White Space'),
+                  ],
                 ],
-                [
-                  VirtualKey(
-                      label: 'a',
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle),
-                  VirtualKey(
-                      label: 'b',
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle),
-                  VirtualKey(
-                      label: 'c',
-                      decoration: keyDecoration,
-                      textStyle: keyTextStyle)
-                ],
-                [
-                  VirtualKey(
-                    decoration: keyDecoration,
-                    type: KeyType.space,
-                    label: 'White Space',
-                  )
-                ],
-              ],
-              keyboardInputController: keyboardController,
-            )
+                keyboardInputController: keyboardController,
+              ),
+            ),
           ],
         ),
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.1"
+    version: "1.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -150,18 +150,18 @@ packages:
     dependency: transitive
     description:
       name: ripple_container
-      sha256: "0467b97d98b018063f759daf53ad91036e12814f1a0bd1bedb182910deb10190"
+      sha256: "885a1bd0232e3061fb59795e959bad7f4502b8cf0829067a69787fb6772a45b9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   size_tailored_text:
     dependency: transitive
     description:
       name: size_tailored_text
-      sha256: "07283bfb65c7781d8c4d6311a8ced37cfc52393a76189fb5e121be067d253de2"
+      sha256: "0a9778ab44541aaab023caf6a1bb1d0b808793ade5fa2a8839970142f07ab28c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/key/key_type.dart
+++ b/lib/src/key/key_type.dart
@@ -8,4 +8,11 @@ enum KeyType {
   enter,
   space,
   clear,
+
+  /// Applies uppercase to the next single character, then automatically
+  /// reverts (one-shot toggle).
+  shift,
+
+  /// Toggles persistent uppercase until pressed again.
+  capsLock,
 }

--- a/lib/src/key/virtual_key.dart
+++ b/lib/src/key/virtual_key.dart
@@ -15,7 +15,8 @@ class VirtualKey {
   final KeyType type;
 
   ///[icon]
-  ///Icon widget to be displayed on the key instead of text or alongside the text.
+  ///Icon widget to be displayed on the key instead of text or
+  ///alongside the text.
   final Icon? icon;
   final Alignment iconAlignment;
 
@@ -26,8 +27,17 @@ class VirtualKey {
   /// [textStyle] key text style
   final TextStyle? textStyle;
 
-  /// If [child] is not null, it is expressed ignoring settings except for [type] and [decoration].
+  /// If [child] is not null, it is expressed ignoring settings except for
+  /// [type] and [decoration].
   final Widget? child;
+
+  /// [onPressed] is called whenever this specific key is pressed.
+  ///
+  /// It runs in addition to the global listener registered through
+  /// [KeyboardInputController.setKeyListener], and fires after the key's
+  /// [type] has been applied to the entered text. The pressed key itself is
+  /// passed as the argument for convenience.
+  final void Function(VirtualKey key)? onPressed;
 
   VirtualKey({
     this.label,
@@ -37,8 +47,181 @@ class VirtualKey {
     this.decoration,
     this.textStyle,
     this.child,
+    this.onPressed,
   }) : assert(
           (child == null ? (type != KeyType.character || label != null) : true),
           'Character keys must have a label',
         );
+
+  /// A character key that inputs [label] into the text buffer.
+  factory VirtualKey.char(
+    String label, {
+    Icon? icon,
+    Alignment iconAlignment = Alignment.topCenter,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// A backspace key that deletes the last entered character.
+  factory VirtualKey.backspace({
+    String? label,
+    Icon? icon,
+    Alignment iconAlignment = Alignment.center,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        type: KeyType.backspace,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// A space key that inputs a single space character.
+  factory VirtualKey.space({
+    String? label,
+    Icon? icon,
+    Alignment iconAlignment = Alignment.center,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        type: KeyType.space,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// An enter key that inputs a newline character.
+  factory VirtualKey.enter({
+    String? label,
+    Icon? icon,
+    Alignment iconAlignment = Alignment.center,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        type: KeyType.enter,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// A clear key that empties the whole text buffer.
+  factory VirtualKey.clear({
+    String? label,
+    Icon? icon,
+    Alignment iconAlignment = Alignment.center,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        type: KeyType.clear,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// A shift key. Applies uppercase to the next single character, then reverts.
+  factory VirtualKey.shift({
+    String? label,
+    Icon? icon,
+    Alignment iconAlignment = Alignment.center,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        type: KeyType.shift,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// A caps-lock key. Toggles persistent uppercase until pressed again.
+  factory VirtualKey.capsLock({
+    String? label,
+    Icon? icon,
+    Alignment iconAlignment = Alignment.center,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) =>
+      VirtualKey(
+        label: label,
+        type: KeyType.capsLock,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        decoration: decoration,
+        textStyle: textStyle,
+        child: child,
+        onPressed: onPressed,
+      );
+
+  /// Returns a copy of this [VirtualKey] with the given fields replaced.
+  ///
+  /// Fields left `null` keep their current value. To intentionally clear an
+  /// optional field, build a new [VirtualKey] instead.
+  VirtualKey copyWith({
+    String? label,
+    KeyType? type,
+    Icon? icon,
+    Alignment? iconAlignment,
+    ContainerDecoration? decoration,
+    TextStyle? textStyle,
+    Widget? child,
+    void Function(VirtualKey key)? onPressed,
+  }) {
+    return VirtualKey(
+      label: label ?? this.label,
+      type: type ?? this.type,
+      icon: icon ?? this.icon,
+      iconAlignment: iconAlignment ?? this.iconAlignment,
+      decoration: decoration ?? this.decoration,
+      textStyle: textStyle ?? this.textStyle,
+      child: child ?? this.child,
+      onPressed: onPressed ?? this.onPressed,
+    );
+  }
 }

--- a/lib/src/keyboard_input_controller.dart
+++ b/lib/src/keyboard_input_controller.dart
@@ -18,10 +18,30 @@ class KeyboardInputController extends ChangeNotifier {
   /// The key is verified as a VirtualKey class type.
   VirtualKey? get lastInputKey => _lastInputKey;
 
+  bool _shiftEnabled = false;
+  bool _capsLockEnabled = false;
+
+  /// Whether the one-shot [KeyType.shift] is currently armed.
+  /// It is consumed (reset to `false`) right after the next character input.
+  bool get isShiftEnabled => _shiftEnabled;
+
+  /// Whether the persistent [KeyType.capsLock] is currently on.
+  bool get isCapsLockEnabled => _capsLockEnabled;
+
+  /// Whether the next character will be entered in uppercase.
+  /// Shift inverts Caps Lock, mirroring physical keyboards.
+  bool get isUpperCase => _capsLockEnabled ^ _shiftEnabled;
+
   Function()? _keyEventListener;
 
   void setKeyListener(
-      Function(VirtualKey? lastKey, String enteredText) listener) {
+    Function(VirtualKey? lastKey, String enteredText) listener,
+  ) {
+    // Remove any previously registered listener so repeated calls do not
+    // accumulate listeners on the underlying ChangeNotifier.
+    if (_keyEventListener != null) {
+      super.removeListener(_keyEventListener!);
+    }
     _keyEventListener = () {
       listener(_lastInputKey, text);
     };
@@ -40,8 +60,12 @@ class KeyboardInputController extends ChangeNotifier {
     switch (key.type) {
       case KeyType.character:
         if (key.label != null) {
-          _textBuffer.write(key.label); // 문자 키 추가
+          // Apply the current shift / caps-lock state to the character.
+          _textBuffer
+              .write(isUpperCase ? key.label!.toUpperCase() : key.label);
         }
+        // Shift is a one-shot modifier: consume it after a character input.
+        _shiftEnabled = false;
       case KeyType.backspace:
         if (_textBuffer.isNotEmpty) {
           _removeLastString(_textBuffer);
@@ -52,9 +76,17 @@ class KeyboardInputController extends ChangeNotifier {
         _textBuffer.write(' ');
       case KeyType.clear:
         _textBuffer.clear();
+      case KeyType.shift:
+        _shiftEnabled = !_shiftEnabled;
+      case KeyType.capsLock:
+        _capsLockEnabled = !_capsLockEnabled;
     }
     _lastInputKey = key;
     notifyListeners();
+
+    // Per-key callback runs after the key's effect has been applied and
+    // listeners were notified, so handlers observe the up-to-date [text].
+    key.onPressed?.call(key);
   }
 
   void clear() {
@@ -63,12 +95,11 @@ class KeyboardInputController extends ChangeNotifier {
   }
 
   void _removeLastString(StringBuffer buffer) {
-    if (buffer.isNotEmpty) {
-      String current = buffer.toString();
-      buffer.clear();
-      if (current.isNotEmpty) {
-        buffer.write(current.substring(0, current.length - 1));
-      }
-    }
+    if (buffer.isEmpty) return;
+    // Remove the last user-perceived character (grapheme cluster) instead of a
+    // single UTF-16 code unit, so emoji / combined characters are not corrupted.
+    final String current = buffer.toString();
+    buffer.clear();
+    buffer.write(current.characters.skipLast(1).toString());
   }
 }

--- a/lib/src/soft_keyboard_widget.dart
+++ b/lib/src/soft_keyboard_widget.dart
@@ -3,22 +3,26 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:flutter_soft_keyboard/src/key/key_type.dart';
 import 'package:flutter_soft_keyboard/src/key/key_widget.dart';
 import 'package:flutter_soft_keyboard/src/key/virtual_key.dart';
 import 'package:flutter_soft_keyboard/src/keyboard_input_controller.dart';
+import 'package:ripple_container/widget/container_decoration.dart';
 import 'package:ripple_container/widget/ripple_callbacks.dart';
 
 
 class SoftKeyboardWidget extends StatefulWidget {
   /// This widget operates only within the size defined by [width] and [height].
-  /// Keys specified in [keyLayout] are positioned within the boundaries of [width] and [height].
+  /// Keys specified in [keyLayout] are positioned within the boundaries of
+  /// [width] and [height].
   final double width;
   final double height;
 
   final KeyboardInputController keyboardInputController;
 
   /// [keyLayout] is a crucial variable for implementing the key arrangement.
-  /// When provided as a 2D array, keys in each array are aligned and displayed accordingly.
+  /// When provided as a 2D array, keys in each array are aligned and displayed
+  /// accordingly.
   ///
   /// example
   /// [
@@ -29,6 +33,15 @@ class SoftKeyboardWidget extends StatefulWidget {
   final List<List<VirtualKey>> keyLayout;
   final double columnSpacing;
   final double rowSpacing;
+
+  /// Default decoration applied to every key that does not define its own
+  /// [VirtualKey.decoration]. Lets you avoid repeating the same decoration on
+  /// each key.
+  final ContainerDecoration? defaultKeyDecoration;
+
+  /// Default text style applied to every key that does not define its own
+  /// [VirtualKey.textStyle]. A per-key [VirtualKey.textStyle] takes precedence.
+  final TextStyle? defaultKeyTextStyle;
 
   // /// If `true`, the key size is determined based on the row with the most keys,
   // /// ensuring all keys maintain a uniform size and fill the available space as much as possible.
@@ -44,6 +57,8 @@ class SoftKeyboardWidget extends StatefulWidget {
     required this.keyLayout,
     this.columnSpacing = 6,
     this.rowSpacing = 6,
+    this.defaultKeyDecoration,
+    this.defaultKeyTextStyle,
     super.key,
   });
 
@@ -61,7 +76,10 @@ class _SoftKeyboardWidgetState extends State<SoftKeyboardWidget> {
     super.initState();
 
     itemHeight = calItemHeight(
-        widget.height, widget.rowSpacing, widget.keyLayout.length);
+      widget.height,
+      widget.rowSpacing,
+      widget.keyLayout.length,
+    );
 
     // if (widget.fitToMaxRow) {
     //   final longIndex = findLongestRowIndex(widget.keyLayout);
@@ -89,23 +107,29 @@ class _SoftKeyboardWidgetState extends State<SoftKeyboardWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: widget.width,
-      height: widget.height,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: widget.keyLayout.indexed.map((e) {
-          final rowIndex = e.$1;
-          final row = e.$2;
-          return Container(
-            width: widget.width,
-            height: itemHeight,
-            margin: EdgeInsets.only(
-              top: rowIndex == 0 ? 0 : widget.rowSpacing,
-            ),
-            child: keyRow(rowIndex, row),
-          );
-        }).toList(),
+    // Rebuild when shift / caps-lock state changes so key faces reflect the
+    // current case. For keyboards without shift/caps keys the state never
+    // changes, so this rebuilds no more often than before.
+    return ListenableBuilder(
+      listenable: widget.keyboardInputController,
+      builder: (context, _) => SizedBox(
+        width: widget.width,
+        height: widget.height,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: widget.keyLayout.indexed.map((e) {
+            final rowIndex = e.$1;
+            final row = e.$2;
+            return Container(
+              width: widget.width,
+              height: itemHeight,
+              margin: EdgeInsets.only(
+                top: rowIndex == 0 ? 0 : widget.rowSpacing,
+              ),
+              child: keyRow(rowIndex, row),
+            );
+          }).toList(),
+        ),
       ),
     );
   }
@@ -118,39 +142,52 @@ class _SoftKeyboardWidgetState extends State<SoftKeyboardWidget> {
               (widget.width - widget.columnSpacing * (list.length - 1)) /
                   list.length;
 
+          // Apply widget-level defaults to any key that did not set its own
+          // decoration / text style, so callers don't repeat them per key.
+          final key = e.$2.copyWith(
+            decoration: e.$2.decoration ?? widget.defaultKeyDecoration,
+            textStyle: e.$2.textStyle ?? widget.defaultKeyTextStyle,
+          );
+
+          // The face may show an uppercased label while shift / caps-lock is
+          // active, but the original key is what drives input so the
+          // controller stays the single source of truth for casing.
+          final displayKey = _displayKey(key);
+
           return KeyWidget(
             keyboardInputController: widget.keyboardInputController,
-            keyData: e.$2,
+            keyData: displayKey,
             rippleCallbacks: RippleCallbacks(
-              onTapDown: (_) => widget.keyboardInputController.onKeyPress(e.$2),
-              onDragEnd: (_) => widget.keyboardInputController.onKeyPress(e.$2),
+              onTapDown: (_) => widget.keyboardInputController.onKeyPress(key),
+              onDragEnd: (_) => widget.keyboardInputController.onKeyPress(key),
             ),
             width: itemWidth,
             height: double.maxFinite,
             margin: EdgeInsets.only(
               left: columnIndex == 0 ? 0 : widget.columnSpacing,
             ),
-            textStyle: e.$2.textStyle,
-            child: e.$2.child,
+            textStyle: displayKey.textStyle,
+            child: displayKey.child,
           );
         }).toList(),
       );
 
-  int findLongestRowIndex(List<List<VirtualKey>> keyLayout) {
-    int maxIndex = 0;
-    int maxLength = 0;
-
-    for (int i = 0; i < keyLayout.length; i++) {
-      if (keyLayout[i].length > maxLength) {
-        maxLength = keyLayout[i].length;
-        maxIndex = i;
-      }
+  /// Returns the key to render. Character keys with a plain text label are
+  /// shown uppercased while shift / caps-lock is active; custom [child] keys
+  /// are left untouched.
+  VirtualKey _displayKey(VirtualKey key) {
+    if (key.type != KeyType.character ||
+        key.child != null ||
+        (key.label ?? '').isEmpty ||
+        !widget.keyboardInputController.isUpperCase) {
+      return key;
     }
-
-    return maxIndex;
+    return key.copyWith(label: key.label!.toUpperCase());
   }
 
   double calItemHeight(double areaHeight, double rowSpacing, int rowLength) {
+    // Guard against an empty layout to avoid division by zero (Infinity/NaN).
+    if (rowLength <= 0) return 0;
     double itemHeight = (areaHeight - rowSpacing * (rowLength - 1)) / rowLength;
     final checkSum = itemHeight * rowLength + rowSpacing * (rowLength - 1);
     if (areaHeight - checkSum < 0) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_soft_keyboard
 description: "This Flutter package is a virtual keyboard widget that can be implemented using a 2D array."
-version: 1.2.1
+version: 1.3.0
 homepage: "https://aqoong.site/"
 repository: "https://github.com/aqoong/flutter_soft_keyboard"
 issue_tracker: "https://github.com/aqoong/flutter_soft_keyboard/issues"
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  size_tailored_text: ^1.1.0
-  ripple_container: ^1.2.0
+  size_tailored_text: ^1.1.1
+  ripple_container: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/soft_keyboard_test.dart
+++ b/test/soft_keyboard_test.dart
@@ -1,1 +1,146 @@
-void main() {}
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_soft_keyboard/flutter_soft_keyboard.dart';
+
+void main() {
+  group('KeyboardInputController', () {
+    test('appends character labels to text', () {
+      final controller = KeyboardInputController();
+      controller.onKeyPress(VirtualKey(label: 'a'));
+      controller.onKeyPress(VirtualKey(label: 'b'));
+      expect(controller.text, 'ab');
+      controller.dispose();
+    });
+
+    test('backspace removes a whole grapheme cluster (emoji safe)', () {
+      final controller = KeyboardInputController();
+      controller.onKeyPress(VirtualKey(label: '👍'));
+      expect(controller.text, '👍');
+
+      controller.onKeyPress(VirtualKey(type: KeyType.backspace));
+      expect(
+        controller.text,
+        isEmpty,
+        reason: 'emoji surrogate pair should be removed as a single unit',
+      );
+      controller.dispose();
+    });
+
+    test('space, enter and clear behave correctly', () {
+      final controller = KeyboardInputController();
+      controller.onKeyPress(VirtualKey(label: 'a'));
+      controller.onKeyPress(VirtualKey(type: KeyType.space));
+      controller.onKeyPress(VirtualKey(label: 'b'));
+      controller.onKeyPress(VirtualKey(type: KeyType.enter));
+      expect(controller.text, 'a b\n');
+
+      controller.onKeyPress(VirtualKey(type: KeyType.clear));
+      expect(controller.text, isEmpty);
+      controller.dispose();
+    });
+
+    test('setKeyListener does not accumulate listeners when called repeatedly',
+        () {
+      final controller = KeyboardInputController();
+      var calls = 0;
+      controller.setKeyListener((_, __) => calls++);
+      controller.setKeyListener((_, __) => calls++);
+
+      controller.onKeyPress(VirtualKey(label: 'a'));
+      expect(calls, 1, reason: 'only the latest listener should fire once');
+      controller.dispose();
+    });
+  });
+
+  group('shift / capsLock', () {
+    test('shift uppercases only the next single character', () {
+      final controller = KeyboardInputController();
+      controller.onKeyPress(VirtualKey.shift());
+      expect(controller.isShiftEnabled, isTrue);
+      expect(controller.isUpperCase, isTrue);
+
+      controller.onKeyPress(VirtualKey.char('a'));
+      expect(controller.text, 'A');
+      expect(
+        controller.isShiftEnabled,
+        isFalse,
+        reason: 'shift should be consumed after one character',
+      );
+
+      controller.onKeyPress(VirtualKey.char('b'));
+      expect(controller.text, 'Ab');
+      controller.dispose();
+    });
+
+    test('capsLock persists until pressed again', () {
+      final controller = KeyboardInputController();
+      controller.onKeyPress(VirtualKey.capsLock());
+      expect(controller.isCapsLockEnabled, isTrue);
+
+      controller.onKeyPress(VirtualKey.char('a'));
+      controller.onKeyPress(VirtualKey.char('b'));
+      expect(controller.text, 'AB');
+
+      controller.onKeyPress(VirtualKey.capsLock());
+      controller.onKeyPress(VirtualKey.char('c'));
+      expect(controller.text, 'ABc');
+      controller.dispose();
+    });
+
+    test('shift inverts capsLock (both on => lowercase)', () {
+      final controller = KeyboardInputController();
+      controller.onKeyPress(VirtualKey.capsLock());
+      controller.onKeyPress(VirtualKey.shift());
+      expect(controller.isUpperCase, isFalse);
+
+      controller.onKeyPress(VirtualKey.char('a'));
+      expect(controller.text, 'a');
+      controller.dispose();
+    });
+  });
+
+  group('VirtualKey per-key onPressed', () {
+    test('fires after the key effect is applied', () {
+      final controller = KeyboardInputController();
+      String? seen;
+      final key = VirtualKey.char(
+        'a',
+        onPressed: (_) => seen = controller.text,
+      );
+      controller.onKeyPress(key);
+      expect(seen, 'a', reason: 'callback should observe up-to-date text');
+      controller.dispose();
+    });
+  });
+
+  group('VirtualKey factory constructors', () {
+    test('assign the expected key types', () {
+      expect(VirtualKey.char('a').type, KeyType.character);
+      expect(VirtualKey.backspace().type, KeyType.backspace);
+      expect(VirtualKey.space().type, KeyType.space);
+      expect(VirtualKey.enter().type, KeyType.enter);
+      expect(VirtualKey.clear().type, KeyType.clear);
+      expect(VirtualKey.shift().type, KeyType.shift);
+      expect(VirtualKey.capsLock().type, KeyType.capsLock);
+    });
+  });
+
+  group('VirtualKey.copyWith', () {
+    test('overrides only the provided fields', () {
+      final base = VirtualKey(label: 'a');
+      final copy = base.copyWith(label: 'b');
+      expect(copy.label, 'b');
+      expect(copy.type, KeyType.character);
+    });
+
+    test('keeps original values when no override is given', () {
+      final base = VirtualKey(
+        label: 'x',
+        textStyle: const TextStyle(fontSize: 12),
+      );
+      final copy = base.copyWith();
+      expect(copy.label, 'x');
+      expect(copy.textStyle?.fontSize, 12);
+    });
+  });
+}


### PR DESCRIPTION
### Added
- 키별 `onPressed` 콜백을 `VirtualKey`에 추가했습니다. 키가 눌리면 전역 리스너와
  별개로, 입력이 반영된 뒤 호출됩니다.
- `SoftKeyboardWidget`에 `defaultKeyDecoration` / `defaultKeyTextStyle`를 추가했습니다.
  모든 키에 공통 적용되며, 개별 `VirtualKey`가 값을 지정하면 그 값이 우선합니다.
  이제 키마다 decoration/textStyle을 반복하지 않아도 됩니다.
- 특수키를 간결하게 만드는 팩토리 생성자를 추가했습니다:
  `VirtualKey.char`, `VirtualKey.backspace`, `VirtualKey.space`,
  `VirtualKey.enter`, `VirtualKey.clear`.
- `KeyType`에 `shift`, `capsLock`을 추가했습니다. `shift`는 다음 문자 하나에만
  적용되는 일회성 토글, `capsLock`은 다시 누를 때까지 유지되는 토글입니다.
  `VirtualKey.shift()` / `VirtualKey.capsLock()` 팩토리 생성자와,
  `KeyboardInputController`의 상태 게터(`isShiftEnabled`, `isCapsLockEnabled`,
  `isUpperCase`)를 함께 제공합니다. Shift/CapsLock 상태에 따라 키 라벨과 입력
  문자가 대문자로 자동 변환됩니다.
- `VirtualKey.copyWith`를 추가했습니다.

### Fixed
- `setKeyListener`를 여러 번 호출하면 이전 리스너가 제거되지 않고 계속 누적되던 문제를 수정했습니다.
  이제 새 리스너를 등록하기 전에 기존 리스너를 해제합니다.
- Backspace가 UTF-16 코드 유닛 1개만 제거해 이모지·결합 문자가 깨지던 문제를 수정했습니다.
  이제 사용자가 인지하는 문자(grapheme cluster) 단위로 제거합니다.
- `keyLayout`가 비어 있을 때 키 높이 계산에서 0으로 나눠 레이아웃이 깨지던 문제를 방지하는 가드를 추가했습니다.